### PR TITLE
sample: Fix compilation errors with g++ 4.9

### DIFF
--- a/sample/basic.cc
+++ b/sample/basic.cc
@@ -4,6 +4,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <vector>
+#include <string.h>
 
 #include "regit.h"
 


### PR DESCRIPTION
The original error messages:
    error: 'strcmp' was not declared in this scope
